### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test",
     "detect"
   ],
+  "files": ["index.js"],
   "author": "Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Prevents `.travis.yml` and `test.js` from being published to NPM.