### PR TITLE
Add AWS CodeBuild to CI detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ var vendors = [
   ['HUDSON', 'Hudsun', 'HUDSON_URL'],
   ['TASKCLUSTER', 'TaskCluster', 'TASK_ID', 'RUN_ID'],
   ['GOCD', 'GoCD', 'GO_PIPELINE_LABEL'],
-  ['BITBUCKET', 'Bitbucket Pipelines', 'BITBUCKET_COMMIT']
+  ['BITBUCKET', 'Bitbucket Pipelines', 'BITBUCKET_COMMIT'],
+  ['CODEBUILD', 'AWS CodeBuild', 'CODEBUILD_BUILD_ARN']
 ]
 
 exports.name = null

--- a/test.js
+++ b/test.js
@@ -26,6 +26,7 @@ assert.equal(ci.HUDSON, false)
 assert.equal(ci.TASKCLUSTER, false)
 assert.equal(ci.GOCD, false)
 assert.equal(ci.BITBUCKET, false)
+assert.equal(ci.CODEBUILD, false)
 
 // Not CI
 delete process.env.CI
@@ -54,6 +55,7 @@ assert.equal(ci.HUDSON, false)
 assert.equal(ci.TASKCLUSTER, false)
 assert.equal(ci.GOCD, false)
 assert.equal(ci.BITBUCKET, false)
+assert.equal(ci.CODEBUILD, false)
 
 // Unknown CI
 process.env.CI = 'true'
@@ -79,3 +81,4 @@ assert.equal(ci.HUDSON, false)
 assert.equal(ci.TASKCLUSTER, false)
 assert.equal(ci.GOCD, false)
 assert.equal(ci.BITBUCKET, false)
+assert.equal(ci.CODEBUILD, false)


### PR DESCRIPTION
Adds a check for AWS CodeBuild. The relevant documentation on environment variables is [here](http://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html#build-env-ref-env-vars).

Thanks for the great package!