### PR TITLE
address #7 and #22

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ exports.isCI = !!(
   env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
   env.BUILD_NUMBER || // Jenkins, TeamCity
   env.RUN_ID || // TaskCluster, dsari
+  // Azure Pipelines
+  (env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI && env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI.startsWith('https://dev.azure.com')) ||
   exports.name ||
   false
 )

--- a/test.js
+++ b/test.js
@@ -91,6 +91,42 @@ test('AppVeyor - Not PR', function (t) {
   t.end()
 })
 
+test('Azure Pipelines - PR', function (t) {
+  process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = 'https://dev.azure.com/Contoso'
+  process.env.SYSTEM_PULLREQUEST_PULLREQUESTID = '42'
+
+  clearRequire('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, true)
+  t.equal(ci.name, 'Azure Pipelines')
+  t.equal(ci.AZURE_PIPELINES, true)
+  assertVendorConstants('AZURE_PIPELINES', ci, t)
+
+  delete process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI
+  delete process.env.SYSTEM_PULLREQUEST_PULLREQUESTID
+
+  t.end()
+})
+
+test('Azure Pipelines - Not PR', function (t) {
+  process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = 'https://dev.azure.com/Contoso'
+
+  clearRequire('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, false)
+  t.equal(ci.name, 'Azure Pipelines')
+  t.equal(ci.AZURE_PIPELINES, true)
+  assertVendorConstants('AZURE_PIPELINES', ci, t)
+
+  delete process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI
+
+  t.end()
+})
+
 test('Buildkite - PR', function (t) {
   process.env.BUILDKITE = 'true'
   process.env.BUILDKITE_PULL_REQUEST = '42'

--- a/vendors.json
+++ b/vendors.json
@@ -6,6 +6,12 @@
     "pr": "APPVEYOR_PULL_REQUEST_NUMBER"
   },
   {
+    "name": "Azure Pipelines",
+    "constant": "AZURE_PIPELINES",
+    "env": "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+    "pr": "SYSTEM_PULLREQUEST_PULLREQUESTID"
+  },
+  {
     "name": "Bamboo",
     "constant": "BAMBOO",
     "env": "bamboo_planKey"


### PR DESCRIPTION
Add detection for Azure Pipelines.

Azure Pipelines is the new name for both TFS Build and VSTS Build. Detection is a little messy because  we intentionally don't make it obvious whether you're running on-premises (Azure DevOps Server) or hosted (Azure DevOps Services). I left TF_BUILD as the indicator for TFS, and did URL path-math on our new domain name to check for Azure Pipelines.