### PR TITLE
add support for Now

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Officially supported CI servers:
 | [TaskCluster](http://docs.taskcluster.net) | `ci.TASKCLUSTER` | 🚫 |
 | [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains | `ci.TEAMCITY` | 🚫 |
 | [Travis CI](http://travis-ci.org) | `ci.TRAVIS` | ✅ |
+| [Zeit Now](https://zeit.co/) | `ci.ZEIT_NOW` | 🚫 |
 
 ## API
 

--- a/test.js
+++ b/test.js
@@ -459,6 +459,23 @@ test('Netlify CI - Not PR', function (t) {
   t.end()
 })
 
+test('ZEIT Now CI', function (t) {
+  process.env.NOW_BUILDER = 'true'
+
+  clearModule('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, null)
+  t.equal(ci.name, 'ZEIT Now')
+  t.equal(ci.ZEIT_NOW, true)
+  assertVendorConstants('ZEIT_NOW', ci, t)
+
+  delete process.env.NOW_BUILDER
+
+  t.end()
+})
+
 function assertVendorConstants (expect, ci, t) {
   ci._vendors.forEach(function (constant) {
     var bool = constant === expect

--- a/test.js
+++ b/test.js
@@ -461,7 +461,7 @@ test('Netlify CI - Not PR', function (t) {
 
 test('ZEIT Now CI', function (t) {
   process.env.NOW_BUILDER = 'true'
-  
+
   clearModule('./')
   var ci = require('./')
 
@@ -472,7 +472,7 @@ test('ZEIT Now CI', function (t) {
   assertVendorConstants('ZEIT_NOW', ci, t)
 
   delete process.env.NOW_BUILDER
-  
+
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -481,9 +481,9 @@ test('Nevercode - PR', function (t) {
   process.env.NEVERCODE_PULL_REQUEST = 'true'
 
   clearModule('./')
-  var ci = require('./')	  var ci = require('./')
+  var ci = require('./')
 
-  t.equal(ci.isCI, true)	  t.equal(ci.isCI, true)
+  t.equal(ci.isCI, true)
   t.equal(ci.isPR, true)
   t.equal(ci.name, 'Nevercode')
   t.equal(ci.NEVERCODE, true)

--- a/test.js
+++ b/test.js
@@ -480,6 +480,10 @@ test('Nevercode - PR', function (t) {
   process.env.NEVERCODE = 'true'
   process.env.NEVERCODE_PULL_REQUEST = 'true'
 
+  clearModule('./')
+  var ci = require('./')	  var ci = require('./')
+
+  t.equal(ci.isCI, true)	  t.equal(ci.isCI, true)
   t.equal(ci.isPR, true)
   t.equal(ci.name, 'Nevercode')
   t.equal(ci.NEVERCODE, true)

--- a/vendors.json
+++ b/vendors.json
@@ -95,7 +95,7 @@
     "pr": { "any": ["ghprbPullId", "CHANGE_ID"] }
   },
   {
-    "name": "Now",
+    "name": "ZEIT Now",
     "constant": "NOW",
     "env": "NOW_REGION"
   },

--- a/vendors.json
+++ b/vendors.json
@@ -96,7 +96,7 @@
   },
   {
     "name": "ZEIT Now",
-    "constant": "NOW",
+    "constant": "ZEIT_NOW",
     "env": "NOW_BUILDER_ANNOTATE"
   },
   {

--- a/vendors.json
+++ b/vendors.json
@@ -97,7 +97,7 @@
   {
     "name": "ZEIT Now",
     "constant": "NOW",
-    "env": "NOW_REGION"
+    "env": "NOW_BUILDER_ANNOTATE"
   },
   {
     "name": "Magnum CI",

--- a/vendors.json
+++ b/vendors.json
@@ -97,7 +97,7 @@
   {
     "name": "ZEIT Now",
     "constant": "ZEIT_NOW",
-    "env": "NOW_BUILDER_ANNOTATE"
+    "env": "NOW_BUILDER"
   },
   {
     "name": "Magnum CI",

--- a/vendors.json
+++ b/vendors.json
@@ -95,6 +95,11 @@
     "pr": { "any": ["ghprbPullId", "CHANGE_ID"] }
   },
   {
+    "name": "Now",
+    "constant": "NOW",
+    "env": "NOW_REGION"
+  },
+  {
     "name": "Magnum CI",
     "constant": "MAGNUM",
     "env": "MAGNUM"


### PR DESCRIPTION
[Now](https://zeit.co/now) defines a `NOW_REGION` env variable: https://zeit.co/docs/v2/deployments/environment-variables-and-secrets/#built-in-variables 