### PR TITLE
Converted vendors.json to vendor.js, export the array of available ci options instead.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var vendors = require('./vendors.json')
+var vendors = require('./vendors.js')
 
 var env = process.env
 

--- a/vendors.js
+++ b/vendors.js
@@ -1,4 +1,4 @@
-[
+module.exports = [
   {
     "name": "AppVeyor",
     "constant": "APPVEYOR",


### PR DESCRIPTION
In projects that have testing frameworks with file mocking capabilities (e.g. Jest with moduleNameMapper), some implementations could replace the contents of `.json` with an empty {} mock. Since these configurations could be global, it will also affect `vendors.json`, as well. It is more reliable to convert this list into an exportable json payload from a js file so it won't run into these false positives.