### PR TITLE
Add GitHub Actions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Officially supported CI servers:
 | [Codeship](https://codeship.com) | `ci.CODESHIP` | 🚫 |
 | [Drone](https://drone.io) | `ci.DRONE` | ✅ |
 | [dsari](https://github.com/rfinnie/dsari) | `ci.DSARI` | 🚫 |
+| [GitHub Actions](https://github.com/features/actions/) | `ci.GITHUB_ACTIONS` | ✅ |
 | [GitLab CI](https://about.gitlab.com/gitlab-ci/) | `ci.GITLAB` | 🚫 |
 | [GoCD](https://www.go.cd/) | `ci.GOCD` | 🚫 |
 | [Hudson](http://hudson-ci.org) | `ci.HUDSON` | 🚫 |

--- a/test.js
+++ b/test.js
@@ -497,6 +497,44 @@ test('Nevercode - Not PR', function (t) {
   t.end()
 })
 
+test('GitHub Actions - PR', function (t) {
+  process.env.GITHUB_ACTIONS = 'true'
+  process.env.GITHUB_EVENT_NAME = 'pull_request'
+
+  clearModule('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, true)
+  t.equal(ci.name, 'GitHub Actions')
+  t.equal(ci.GITHUB_ACTIONS, true)
+  assertVendorConstants('GITHUB_ACTIONS', ci, t)
+
+  delete process.env.GITHUB_ACTIONS
+  delete process.env.GITHUB_EVENT_NAME
+
+  t.end()
+})
+
+test('GitHub Actions - Not PR', function (t) {
+  process.env.GITHUB_ACTIONS = 'true'
+  process.env.GITHUB_EVENT_NAME = 'push'
+
+  clearModule('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, false)
+  t.equal(ci.name, 'GitHub Actions')
+  t.equal(ci.GITHUB_ACTIONS, true)
+  assertVendorConstants('GITHUB_ACTIONS', ci, t)
+
+  delete process.env.GITHUB_ACTIONS
+  delete process.env.GITHUB_EVENT_NAME
+
+  t.end()
+})
+
 function assertVendorConstants (expect, ci, t) {
   ci._vendors.forEach(function (constant) {
     var bool = constant === expect

--- a/vendors.json
+++ b/vendors.json
@@ -74,6 +74,12 @@
     "env": "DSARI"
   },
   {
+    "name": "GitHub Actions",
+    "constant": "GITHUB_ACTIONS",
+    "env": "GITHUB_ACTIONS",
+    "pr": { "GITHUB_EVENT_NAME": "pull_request" }
+  },
+  {
     "name": "GitLab CI",
     "constant": "GITLAB",
     "env": "GITLAB_CI"


### PR DESCRIPTION
Add support for detecting a run inside a [GitHub Actions](https://github.com/features/actions) environment.  This detects using the `GITHUB_ACTIONS` environment variable, and detects a pull request run by examining the `GITHUB_EVENT_NAME` environment variable, which indicates why a GitHub Actions run was started.  When it is set to `pull_request`, we set `isPR` to true.