### PR TITLE
Fix Netlify detection

### DIFF
--- a/test.js
+++ b/test.js
@@ -460,7 +460,7 @@ test('Travis CI - Not PR', function (t) {
 })
 
 test('Netlify CI - PR', function (t) {
-  process.env.NETLIFY_BUILD_BASE = '/opt/build'
+  process.env.NETLIFY = 'true'
   process.env.PULL_REQUEST = 'true'
 
   clearModule('./')
@@ -472,14 +472,14 @@ test('Netlify CI - PR', function (t) {
   t.equal(ci.NETLIFY, true)
   assertVendorConstants('NETLIFY', ci, t)
 
-  delete process.env.NETLIFY_BUILD_BASE
+  delete process.env.NETLIFY
   delete process.env.PULL_REQUEST
 
   t.end()
 })
 
 test('Netlify CI - Not PR', function (t) {
-  process.env.NETLIFY_BUILD_BASE = '/opt/build'
+  process.env.NETLIFY = 'true'
   process.env.PULL_REQUEST = 'false'
 
   clearModule('./')
@@ -491,7 +491,7 @@ test('Netlify CI - Not PR', function (t) {
   t.equal(ci.NETLIFY, true)
   assertVendorConstants('NETLIFY', ci, t)
 
-  delete process.env.NETLIFY_BUILD_BASE
+  delete process.env.NETLIFY
   delete process.env.PULL_REQUEST
 
   t.end()

--- a/vendors.json
+++ b/vendors.json
@@ -113,7 +113,7 @@
   {
     "name": "Netlify CI",
     "constant": "NETLIFY",
-    "env": "NETLIFY_BUILD_BASE",
+    "env": "NETLIFY",
     "pr": { "env": "PULL_REQUEST", "ne": "false" }
   },
   {


### PR DESCRIPTION
Currently `ci-info` detects Netlify using the `NETLIFY_BUILD_BASE` environment variable. While this will work, that environment variable is undocumented. This PR changes it to the [documented](https://docs.netlify.com/configure-builds/environment-variables/#build-metadata) `NETLIFY=true` environment variable instead.

Tests are updated too.