### PR TITLE
docs: update Gitlab CI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Officially supported CI servers:
 | [Drone](https://drone.io) | `ci.DRONE` | ✅ |
 | [dsari](https://github.com/rfinnie/dsari) | `ci.DSARI` | 🚫 |
 | [GitHub Actions](https://github.com/features/actions/) | `ci.GITHUB_ACTIONS` | ✅ |
-| [GitLab CI](https://about.gitlab.com/gitlab-ci/) | `ci.GITLAB` | 🚫 |
+| [GitLab CI](https://about.gitlab.com/gitlab-ci/) | `ci.GITLAB` | ✅ |
 | [GoCD](https://www.go.cd/) | `ci.GOCD` | 🚫 |
 | [Hudson](http://hudson-ci.org) | `ci.HUDSON` | 🚫 |
 | [Jenkins CI](https://jenkins-ci.org) | `ci.JENKINS` | ✅ |


### PR DESCRIPTION
The README should show that Gitlab _is_ supported.