### PR TITLE
Replace ZEIT Now with Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Officially supported CI servers:
 | [TaskCluster](http://docs.taskcluster.net) | `ci.TASKCLUSTER` | 🚫 |
 | [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains | `ci.TEAMCITY` | 🚫 |
 | [Travis CI](http://travis-ci.org) | `ci.TRAVIS` | ✅ |
+| [Vercel](https://vercel.com/) | `ci.VERCEL` | 🚫 |
 | [Zeit Now](https://zeit.co/) | `ci.ZEIT_NOW` | 🚫 |
 
 ## API

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Officially supported CI servers:
 | [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains | `ci.TEAMCITY` | 🚫 |
 | [Travis CI](http://travis-ci.org) | `ci.TRAVIS` | ✅ |
 | [Vercel](https://vercel.com/) | `ci.VERCEL` | 🚫 |
-| [Zeit Now](https://zeit.co/) | `ci.ZEIT_NOW` | 🚫 |
 
 ## API
 

--- a/test.js
+++ b/test.js
@@ -497,23 +497,6 @@ test('Netlify CI - Not PR', function (t) {
   t.end()
 })
 
-test('ZEIT Now CI', function (t) {
-  process.env.NOW_BUILDER = '1'
-
-  clearModule('./')
-  var ci = require('./')
-
-  t.equal(ci.isCI, true)
-  t.equal(ci.isPR, null)
-  t.equal(ci.name, 'ZEIT Now')
-  t.equal(ci.ZEIT_NOW, true)
-  assertVendorConstants('ZEIT_NOW', ci, t)
-
-  delete process.env.NOW_BUILDER
-
-  t.end()
-})
-
 test('Vercel', function (t) {
   process.env.NOW_BUILDER = '1'
 

--- a/test.js
+++ b/test.js
@@ -498,7 +498,7 @@ test('Netlify CI - Not PR', function (t) {
 })
 
 test('ZEIT Now CI', function (t) {
-  process.env.NOW_BUILDER = 'true'
+  process.env.NOW_BUILDER = '1'
 
   clearModule('./')
   var ci = require('./')
@@ -508,6 +508,23 @@ test('ZEIT Now CI', function (t) {
   t.equal(ci.name, 'ZEIT Now')
   t.equal(ci.ZEIT_NOW, true)
   assertVendorConstants('ZEIT_NOW', ci, t)
+
+  delete process.env.NOW_BUILDER
+
+  t.end()
+})
+
+test('Vercel', function (t) {
+  process.env.NOW_BUILDER = '1'
+
+  clearModule('./')
+  var ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, null)
+  t.equal(ci.name, 'Vercel')
+  t.equal(ci.VERCEL, true)
+  assertVendorConstants('VERCEL', ci, t)
 
   delete process.env.NOW_BUILDER
 

--- a/vendors.json
+++ b/vendors.json
@@ -172,5 +172,10 @@
     "constant": "TRAVIS",
     "env": "TRAVIS",
     "pr": { "env": "TRAVIS_PULL_REQUEST", "ne": "false" }
+  },
+  {
+    "name": "Vercel",
+    "constant": "VERCEL",
+    "env": "NOW_BUILDER"
   }
 ]

--- a/vendors.json
+++ b/vendors.json
@@ -101,11 +101,6 @@
     "pr": { "any": ["ghprbPullId", "CHANGE_ID"] }
   },
   {
-    "name": "ZEIT Now",
-    "constant": "ZEIT_NOW",
-    "env": "NOW_BUILDER"
-  },
-  {
     "name": "Magnum CI",
     "constant": "MAGNUM",
     "env": "MAGNUM"


### PR DESCRIPTION
This PR replaces `ci.ZEIT_NOW` with `ci.VERCEL` and updates the tests and the README.

You can find the announcement related to ZEIT becoming Vercel here: https://vercel.com/blog/zeit-is-now-vercel.