### PR TITLE
fix: Support isPR for gitlab

### DIFF
--- a/vendors.json
+++ b/vendors.json
@@ -82,7 +82,8 @@
   {
     "name": "GitLab CI",
     "constant": "GITLAB",
-    "env": "GITLAB_CI"
+    "env": "GITLAB_CI",
+    "pr": "CI_MERGE_REQUEST_ID"
   },
   {
     "name": "GoCD",


### PR DESCRIPTION
Gitlab PR or rather MR (Merge Request) detection didn't work because the `pr` setting was missing in vendors.json

If fixed this by adding `CI_MERGE_REQUEST_ID` which identifies a MR in gitlab.
https://docs.gitlab.com/ee/ci/variables/predefined_variables.html

Closes #58 