### PR TITLE
chore(types): fix typings for EAS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export const CODEFRESH: boolean;
 export const CODESHIP: boolean;
 export const DRONE: boolean;
 export const DSARI: boolean;
-export const EAS_BUILD: boolean;
+export const EAS: boolean;
 export const GITHUB_ACTIONS: boolean;
 export const GITLAB: boolean;
 export const GOCD: boolean;


### PR DESCRIPTION
The constant for EAS is EAS, not EAS_BUILD (according to vendors.json)