### PR TITLE
fix(readme): Fix README for EAS constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Officially supported CI servers:
 | [Codeship](https://codeship.com)                                                | `ci.CODESHIP`        | 🚫   |
 | [Drone](https://drone.io)                                                       | `ci.DRONE`           | ✅   |
 | [dsari](https://github.com/rfinnie/dsari)                                       | `ci.DSARI`           | 🚫   |
-| [Expo Application Services](https://expo.dev/eas)                               | `ci.EAS_BUILD`       | 🚫   |
+| [Expo Application Services](https://expo.dev/eas)                               | `ci.EAS`             | 🚫   |
 | [GitHub Actions](https://github.com/features/actions/)                          | `ci.GITHUB_ACTIONS`  | ✅   |
 | [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | `ci.GITLAB`          | ✅   |
 | [GoCD](https://www.go.cd/)                                                      | `ci.GOCD`            | 🚫   |


### PR DESCRIPTION
The constant for Expo Application Services should be `EAS` instead of `EAS_BUILD`:

https://github.com/watson/ci-info/blob/26718f7234b31ace58763a4fd28f858b3a2fe266/vendors.json#L89

This was a mistake in my original PR, apologies.