### PR TITLE
Parity with @npmcli/ci-detect

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Officially supported CI servers:
 | [Drone](https://drone.io)                                                       | `ci.DRONE`           | ✅   |
 | [dsari](https://github.com/rfinnie/dsari)                                       | `ci.DSARI`           | 🚫   |
 | [Expo Application Services](https://expo.dev/eas)                               | `ci.EAS`             | 🚫   |
+| [Gerrit CI](https://www.gerritcodereview.com)                                   | `ci.GERRIT`          | 🚫   |
 | [GitHub Actions](https://github.com/features/actions/)                          | `ci.GITHUB_ACTIONS`  | ✅   |
 | [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | `ci.GITLAB`          | ✅   |
 | [GoCD](https://www.go.cd/)                                                      | `ci.GOCD`            | 🚫   |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Officially supported CI servers:
 | [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | `ci.GITLAB`             | ✅   |
 | [GoCD](https://www.go.cd/)                                                      | `ci.GOCD`               | 🚫   |
 | [Google Cloud Build](https://cloud.google.com/build)                            | `ci.GOOGLE_CLOUD_BUILD` | 🚫   |
+| [Heroku](https://www.heroku.com)                                                | `ci.HEROKU`             | 🚫   |
 | [Hudson](http://hudson-ci.org)                                                  | `ci.HUDSON`             | 🚫   |
 | [Jenkins CI](https://jenkins-ci.org)                                            | `ci.JENKINS`            | ✅   |
 | [LayerCI](https://layerci.com/)                                                 | `ci.LAYERCI`            | ✅   |

--- a/README.md
+++ b/README.md
@@ -32,47 +32,48 @@ if (ci.isCI) {
 
 Officially supported CI servers:
 
-| Name                                                                            | Constant             | isPR |
-| ------------------------------------------------------------------------------- | -------------------- | ---- |
-| [AWS CodeBuild](https://aws.amazon.com/codebuild/)                              | `ci.CODEBUILD`       | 🚫   |
-| [AppVeyor](http://www.appveyor.com)                                             | `ci.APPVEYOR`        | ✅   |
-| [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | `ci.AZURE_PIPELINES` | ✅   |
-| [Appcircle](https://appcircle.io/)                                              | `ci.APPCIRCLE`       | 🚫   |
-| [Bamboo](https://www.atlassian.com/software/bamboo) by Atlassian                | `ci.BAMBOO`          | 🚫   |
-| [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines)         | `ci.BITBUCKET`       | ✅   |
-| [Bitrise](https://www.bitrise.io/)                                              | `ci.BITRISE`         | ✅   |
-| [Buddy](https://buddy.works/)                                                   | `ci.BUDDY`           | ✅   |
-| [Buildkite](https://buildkite.com)                                              | `ci.BUILDKITE`       | ✅   |
-| [CircleCI](http://circleci.com)                                                 | `ci.CIRCLE`          | ✅   |
-| [Cirrus CI](https://cirrus-ci.org)                                              | `ci.CIRRUS`          | ✅   |
-| [Codefresh](https://codefresh.io/)                                              | `ci.CODEFRESH`       | ✅   |
-| [Codeship](https://codeship.com)                                                | `ci.CODESHIP`        | 🚫   |
-| [Drone](https://drone.io)                                                       | `ci.DRONE`           | ✅   |
-| [dsari](https://github.com/rfinnie/dsari)                                       | `ci.DSARI`           | 🚫   |
-| [Expo Application Services](https://expo.dev/eas)                               | `ci.EAS`             | 🚫   |
-| [Gerrit CI](https://www.gerritcodereview.com)                                   | `ci.GERRIT`          | 🚫   |
-| [GitHub Actions](https://github.com/features/actions/)                          | `ci.GITHUB_ACTIONS`  | ✅   |
-| [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | `ci.GITLAB`          | ✅   |
-| [GoCD](https://www.go.cd/)                                                      | `ci.GOCD`            | 🚫   |
-| [Hudson](http://hudson-ci.org)                                                  | `ci.HUDSON`          | 🚫   |
-| [Jenkins CI](https://jenkins-ci.org)                                            | `ci.JENKINS`         | ✅   |
-| [LayerCI](https://layerci.com/)                                                 | `ci.LAYERCI`         | ✅   |
-| [Magnum CI](https://magnum-ci.com)                                              | `ci.MAGNUM`          | 🚫   |
-| [Netlify CI](https://www.netlify.com/)                                          | `ci.NETLIFY`         | ✅   |
-| [Nevercode](http://nevercode.io/)                                               | `ci.NEVERCODE`       | ✅   |
-| [Render](https://render.com/)                                                   | `ci.RENDER`          | ✅   |
-| [Sail CI](https://sail.ci/)                                                     | `ci.SAIL`            | ✅   |
-| [Screwdriver](https://screwdriver.cd/)                                          | `ci.SCREWDRIVER`     | ✅   |
-| [Semaphore](https://semaphoreci.com)                                            | `ci.SEMAPHORE`       | ✅   |
-| [Shippable](https://www.shippable.com/)                                         | `ci.SHIPPABLE`       | ✅   |
-| [Solano CI](https://www.solanolabs.com/)                                        | `ci.SOLANO`          | ✅   |
-| [Strider CD](https://strider-cd.github.io/)                                     | `ci.STRIDER`         | 🚫   |
-| [TaskCluster](http://docs.taskcluster.net)                                      | `ci.TASKCLUSTER`     | 🚫   |
-| [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains                    | `ci.TEAMCITY`        | 🚫   |
-| [Travis CI](http://travis-ci.org)                                               | `ci.TRAVIS`          | ✅   |
-| [Vercel](https://vercel.com/)                                                   | `ci.VERCEL`          | 🚫   |
-| [Visual Studio App Center](https://appcenter.ms/)                               | `ci.APPCENTER`       | 🚫   |
-| [Woodpecker](https://woodpecker-ci.org/)                                        | `ci.WOODPECKER`      | ✅   |
+| Name                                                                            | Constant                | isPR |
+| ------------------------------------------------------------------------------- | --------------------    | ---- |
+| [AWS CodeBuild](https://aws.amazon.com/codebuild/)                              | `ci.CODEBUILD`          | 🚫   |
+| [AppVeyor](http://www.appveyor.com)                                             | `ci.APPVEYOR`           | ✅   |
+| [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | `ci.AZURE_PIPELINES`    | ✅   |
+| [Appcircle](https://appcircle.io/)                                              | `ci.APPCIRCLE`          | 🚫   |
+| [Bamboo](https://www.atlassian.com/software/bamboo) by Atlassian                | `ci.BAMBOO`             | 🚫   |
+| [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines)         | `ci.BITBUCKET`          | ✅   |
+| [Bitrise](https://www.bitrise.io/)                                              | `ci.BITRISE`            | ✅   |
+| [Buddy](https://buddy.works/)                                                   | `ci.BUDDY`              | ✅   |
+| [Buildkite](https://buildkite.com)                                              | `ci.BUILDKITE`          | ✅   |
+| [CircleCI](http://circleci.com)                                                 | `ci.CIRCLE`             | ✅   |
+| [Cirrus CI](https://cirrus-ci.org)                                              | `ci.CIRRUS`             | ✅   |
+| [Codefresh](https://codefresh.io/)                                              | `ci.CODEFRESH`          | ✅   |
+| [Codeship](https://codeship.com)                                                | `ci.CODESHIP`           | 🚫   |
+| [Drone](https://drone.io)                                                       | `ci.DRONE`              | ✅   |
+| [dsari](https://github.com/rfinnie/dsari)                                       | `ci.DSARI`              | 🚫   |
+| [Expo Application Services](https://expo.dev/eas)                               | `ci.EAS`                | 🚫   |
+| [Gerrit CI](https://www.gerritcodereview.com)                                   | `ci.GERRIT`             | 🚫   |
+| [GitHub Actions](https://github.com/features/actions/)                          | `ci.GITHUB_ACTIONS`     | ✅   |
+| [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | `ci.GITLAB`             | ✅   |
+| [GoCD](https://www.go.cd/)                                                      | `ci.GOCD`               | 🚫   |
+| [Google Cloud Build](https://cloud.google.com/build)                            | `ci.GOOGLE_CLOUD_BUILD` | 🚫   |
+| [Hudson](http://hudson-ci.org)                                                  | `ci.HUDSON`             | 🚫   |
+| [Jenkins CI](https://jenkins-ci.org)                                            | `ci.JENKINS`            | ✅   |
+| [LayerCI](https://layerci.com/)                                                 | `ci.LAYERCI`            | ✅   |
+| [Magnum CI](https://magnum-ci.com)                                              | `ci.MAGNUM`             | 🚫   |
+| [Netlify CI](https://www.netlify.com/)                                          | `ci.NETLIFY`            | ✅   |
+| [Nevercode](http://nevercode.io/)                                               | `ci.NEVERCODE`          | ✅   |
+| [Render](https://render.com/)                                                   | `ci.RENDER`             | ✅   |
+| [Sail CI](https://sail.ci/)                                                     | `ci.SAIL`               | ✅   |
+| [Screwdriver](https://screwdriver.cd/)                                          | `ci.SCREWDRIVER`        | ✅   |
+| [Semaphore](https://semaphoreci.com)                                            | `ci.SEMAPHORE`          | ✅   |
+| [Shippable](https://www.shippable.com/)                                         | `ci.SHIPPABLE`          | ✅   |
+| [Solano CI](https://www.solanolabs.com/)                                        | `ci.SOLANO`             | ✅   |
+| [Strider CD](https://strider-cd.github.io/)                                     | `ci.STRIDER`            | 🚫   |
+| [TaskCluster](http://docs.taskcluster.net)                                      | `ci.TASKCLUSTER`        | 🚫   |
+| [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains                    | `ci.TEAMCITY`           | 🚫   |
+| [Travis CI](http://travis-ci.org)                                               | `ci.TRAVIS`             | ✅   |
+| [Vercel](https://vercel.com/)                                                   | `ci.VERCEL`             | 🚫   |
+| [Visual Studio App Center](https://appcenter.ms/)                               | `ci.APPCENTER`          | 🚫   |
+| [Woodpecker](https://woodpecker-ci.org/)                                        | `ci.WOODPECKER`         | ✅   |
 
 ## API
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ export const GITHUB_ACTIONS: boolean;
 export const GITLAB: boolean;
 export const GOCD: boolean;
 export const GOOGLE_CLOUD_BUILD: boolean;
+export const HEROKU boolean;
 export const HUDSON: boolean;
 export const JENKINS: boolean;
 export const LAYERCI: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,7 @@ export const GERRIT: boolean;
 export const GITHUB_ACTIONS: boolean;
 export const GITLAB: boolean;
 export const GOCD: boolean;
+export const GOOGLE_CLOUD_BUILD: boolean;
 export const HUDSON: boolean;
 export const JENKINS: boolean;
 export const LAYERCI: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ export const CODESHIP: boolean;
 export const DRONE: boolean;
 export const DSARI: boolean;
 export const EAS: boolean;
+export const GERRIT: boolean;
 export const GITHUB_ACTIONS: boolean;
 export const GITLAB: boolean;
 export const GOCD: boolean;

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ vendors.forEach(function (vendor) {
 exports.isCI = !!(
   env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
   env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
+  env.BUILD_ID || // Jenkins, Cloudbees
   env.BUILD_NUMBER || // Jenkins, TeamCity
   env.CI_APP_ID || // Appflow
   env.CI_BUILD_ID || // Appflow

--- a/index.js
+++ b/index.js
@@ -78,6 +78,11 @@ function checkEnv (obj) {
     return env[obj.env] && env[obj.env].includes(obj.includes)
     // }
   }
+  if ('any' in obj) {
+    return obj.any.some(function (k) {
+      return !!env[k]
+    })
+  }
   return Object.keys(obj).every(function (k) {
     return env[k] === obj[k]
   })

--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ exports.isCI = !!(
   env.CI_BUILD_ID || // Appflow
   env.CI_BUILD_NUMBER || // Appflow
   env.RUN_ID || // TaskCluster, dsari
+  env.CI_NAME || // Codeship and others
   exports.name ||
   false
 )

--- a/index.js
+++ b/index.js
@@ -54,15 +54,15 @@ vendors.forEach(function (vendor) {
 })
 
 exports.isCI = !!(
-  env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
-  env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
   env.BUILD_ID || // Jenkins, Cloudbees
   env.BUILD_NUMBER || // Jenkins, TeamCity
+  env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
   env.CI_APP_ID || // Appflow
   env.CI_BUILD_ID || // Appflow
   env.CI_BUILD_NUMBER || // Appflow
-  env.RUN_ID || // TaskCluster, dsari
   env.CI_NAME || // Codeship and others
+  env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
+  env.RUN_ID || // TaskCluster, dsari
   exports.name ||
   false
 )

--- a/index.js
+++ b/index.js
@@ -67,7 +67,16 @@ exports.isCI = !!(
 )
 
 function checkEnv (obj) {
+  // "env": "CIRRUS"
   if (typeof obj === 'string') return !!env[obj]
+
+  // "env": { "env": "NODE", "includes": "/app/.heroku/node/bin/node" }
+  if ('env' in obj) {
+    // Currently there are no other types, uncomment when there are
+    // if ('includes' in obj) {
+    return env[obj.env] && env[obj.env].includes(obj.includes)
+    // }
+  }
   return Object.keys(obj).every(function (k) {
     return env[k] === obj[k]
   })

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "clear-module": "^4.1.2",
     "standard": "^17.0.0",
     "tape": "^5.6.0"
+  },
+  "engines": {
+    "node": ">=8"
   }
 }

--- a/test.js
+++ b/test.js
@@ -58,9 +58,9 @@ test('Unknown CI', function (t) {
 
 test('Anonymous CI', function (t) {
   const ANONYMOUS_ENV_VARS = [
-    'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER',
-    'CI_APP_ID', 'CI_BUILD_ID', 'CI_BUILD_NUMBER',
-    'RUN_ID', 'CI_NAME'
+    'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_ID',
+    'BUILD_NUMBER', 'CI_APP_ID', 'CI_BUILD_ID',
+    'CI_BUILD_NUMBER', 'RUN_ID', 'CI_NAME'
   ]
 
   for (const envVar in ANONYMOUS_ENV_VARS) {

--- a/test.js
+++ b/test.js
@@ -606,7 +606,7 @@ test('Netlify CI - Not PR', function (t) {
   t.end()
 })
 
-test('Vercel', function (t) {
+test('Vercel - NOW_BUILDER', function (t) {
   process.env.NOW_BUILDER = '1'
 
   clearModule('./')
@@ -619,6 +619,23 @@ test('Vercel', function (t) {
   assertVendorConstants('VERCEL', ci, t)
 
   delete process.env.NOW_BUILDER
+
+  t.end()
+})
+
+test('Vercel - VERCEL_URL', function (t) {
+  process.env.VERCEL_URL = '1'
+
+  clearModule('./')
+  const ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, null)
+  t.equal(ci.name, 'Vercel')
+  t.equal(ci.VERCEL, true)
+  assertVendorConstants('VERCEL', ci, t)
+
+  delete process.env.VERCEL_URL
 
   t.end()
 })

--- a/test.js
+++ b/test.js
@@ -860,6 +860,22 @@ test('Xcode Server - Not PR', function (t) {
   t.end()
 })
 
+test('Heroku', function (t) {
+  const realNode = process.env.NODE
+  process.env.NODE = '/extra/content/app/.heroku/node/bin/node --extra --content'
+
+  clearModule('./')
+  const ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.name, 'Heroku')
+  t.equal(ci.HEROKU, true)
+  assertVendorConstants('HEROKU', ci, t)
+
+  process.env.NODE = realNode
+  t.end()
+})
+
 function assertVendorConstants (expect, ci, t) {
   ci._vendors.forEach(function (constant) {
     let bool = constant === expect

--- a/test.js
+++ b/test.js
@@ -60,7 +60,7 @@ test('Anonymous CI', function (t) {
   const ANONYMOUS_ENV_VARS = [
     'CI', 'CONTINUOUS_INTEGRATION', 'BUILD_NUMBER',
     'CI_APP_ID', 'CI_BUILD_ID', 'CI_BUILD_NUMBER',
-    'RUN_ID'
+    'RUN_ID', 'CI_NAME'
   ]
 
   for (const envVar in ANONYMOUS_ENV_VARS) {

--- a/vendors.json
+++ b/vendors.json
@@ -119,6 +119,11 @@
     "pr": "LAYERCI_PULL_REQUEST"
   },
   {
+    "name": "Gerrit",
+    "constant": "GERRIT",
+    "env": "GERRIT_PROJECT"
+  },
+  {
     "name": "Hudson",
     "constant": "HUDSON",
     "env": "HUDSON_URL"

--- a/vendors.json
+++ b/vendors.json
@@ -1,20 +1,25 @@
 [
   {
+    "name": "Appcircle",
+    "constant": "APPCIRCLE",
+    "env": "AC_APPCIRCLE"
+  },
+  {
     "name": "AppVeyor",
     "constant": "APPVEYOR",
     "env": "APPVEYOR",
     "pr": "APPVEYOR_PULL_REQUEST_NUMBER"
   },
   {
+    "name": "AWS CodeBuild",
+    "constant": "CODEBUILD",
+    "env": "CODEBUILD_BUILD_ARN"
+  },
+  {
     "name": "Azure Pipelines",
     "constant": "AZURE_PIPELINES",
     "env": "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
     "pr": "SYSTEM_PULLREQUEST_PULLREQUESTID"
-  },
-  {
-    "name": "Appcircle",
-    "constant": "APPCIRCLE",
-    "env": "AC_APPCIRCLE"
   },
   {
     "name": "Bamboo",
@@ -58,21 +63,16 @@
     "pr": "CIRRUS_PR"
   },
   {
-    "name": "Codemagic",
-    "constant": "CODEMAGIC",
-    "env": "CM_BUILD_ID",
-    "pr": "CM_PULL_REQUEST"
-  },
-  {
-    "name": "AWS CodeBuild",
-    "constant": "CODEBUILD",
-    "env": "CODEBUILD_BUILD_ARN"
-  },
-  {
     "name": "Codefresh",
     "constant": "CODEFRESH",
     "env": "CF_BUILD_ID",
     "pr": { "any": ["CF_PULL_REQUEST_NUMBER", "CF_PULL_REQUEST_ID"] }
+  },
+  {
+    "name": "Codemagic",
+    "constant": "CODEMAGIC",
+    "env": "CM_BUILD_ID",
+    "pr": "CM_PULL_REQUEST"
   },
   {
     "name": "Codeship",
@@ -84,12 +84,6 @@
     "constant": "DRONE",
     "env": "DRONE",
     "pr": { "DRONE_BUILD_EVENT": "pull_request" }
-  },
-  {
-    "name": "Woodpecker",
-    "constant": "WOODPECKER",
-    "env": { "CI": "woodpecker" },
-    "pr": { "CI_BUILD_EVENT": "pull_request" }
   },
   {
     "name": "dsari",
@@ -165,16 +159,16 @@
     "pr": "SAIL_PULL_REQUEST_NUMBER"
   },
   {
-    "name": "Semaphore",
-    "constant": "SEMAPHORE",
-    "env": "SEMAPHORE",
-    "pr": "PULL_REQUEST_NUMBER"
-  },
-  {
     "name": "Screwdriver",
     "constant": "SCREWDRIVER",
     "env": "SCREWDRIVER",
     "pr": { "env": "SD_PULL_REQUEST", "ne": "false" }
+  },
+  {
+    "name": "Semaphore",
+    "constant": "SEMAPHORE",
+    "env": "SEMAPHORE",
+    "pr": "PULL_REQUEST_NUMBER"
   },
   {
     "name": "Shippable",
@@ -218,6 +212,12 @@
     "name": "Visual Studio App Center",
     "constant": "APPCENTER",
     "env": "APPCENTER_BUILD_ID"
+  },
+  {
+    "name": "Woodpecker",
+    "constant": "WOODPECKER",
+    "env": { "CI": "woodpecker" },
+    "pr": { "CI_BUILD_EVENT": "pull_request" }
   },
   {
     "name": "Xcode Cloud",

--- a/vendors.json
+++ b/vendors.json
@@ -221,7 +221,7 @@
   {
     "name": "Vercel",
     "constant": "VERCEL",
-    "env": "NOW_BUILDER"
+    "env": { "any": ["NOW_BUILDER", "VERCEL_URL"] }
   },
   {
     "name": "Visual Studio App Center",

--- a/vendors.json
+++ b/vendors.json
@@ -113,6 +113,11 @@
     "env": "GO_PIPELINE_LABEL"
   },
   {
+    "name": "Google Cloud Build",
+    "constant": "GOOGLE_CLOUD_BUILD",
+    "env": "BUILDER_OUTPUT"
+  },
+  {
     "name": "LayerCI",
     "constant": "LAYERCI",
     "env": "LAYERCI",

--- a/vendors.json
+++ b/vendors.json
@@ -129,6 +129,11 @@
     "env": "GERRIT_PROJECT"
   },
   {
+    "name": "Heroku",
+    "constant": "HEROKU",
+    "env": { "env": "NODE", "includes": "/app/.heroku/node/bin/node" }
+  },
+  {
     "name": "Hudson",
     "constant": "HUDSON",
     "env": "HUDSON_URL"


### PR DESCRIPTION
Greetings from the npm cli team.  We recently had [a bug filed in our own
ci detection library](https://github.com/npm/ci-detect/issues/47) that
brought your library back to our attention.  After doing some digging it
looks like possibly neither of our projects are doing things exactly the
same, and this PR is an attempt to get us in sync with the eventual goal
being to deprecate our library and start using yours.

In order for us to move to this library withouth it constituting a
semver major change in npm itself, we need to at the very least have
your library set `isPr` in the same environments that
`@npmcli/ci-detect` currently does.  None of the other metadata really
matters as far as npm itself is concerned.

This PR gets us MOST of the way via the following commits.  I don't know
if you'd rather these all be separate PRs, or if you want the commits
squashed and the title to cover all the changes.  Whatever works for you
works for us.  Here are the changes present:

- chore: sort vendors.json by name
- feat: add support for gerrit
- feat: add support for google cloud build
- feat: add support for anonymous CI_NAME environments
- feat: add support for Heroku
  - This is based off of the work already started in https://github.com/watson/ci-info/pull/34
- fix: account for jenkins with no JENKINS_URL
  - Takes into account the fact that JENKINS_URL is only set if the user has configured one (as per the [jenkins docs](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#using-environment-variables))
- fix: account for vercel via VERCEL_URL
  - In `@npmcli/ci-detect` we check for `VERCEL_URL`, and considered
      `NOW_BUILDER` to be the pre-aqcuisition "now" environment.  This
      at least brings in the `VERCEL_URL` detection.


`@npmcli/ci-detect` currently also checks for Wercker, but that does not
appear to be in use anymore so it was not included in this PR.

As far as the three vercel environments `vercel-bitbucket`,
`vercel-gitlab`, and `vercel-github`, I have asked some folks at vercel
if detecting `VERCEL_URL` is sufficient for knowing if one is generally
in any of those environments, if so `isCi` is going to be true still and
this will mean detection parity with `@npmcli/ci-detect`

One final side-note.  It doesn't appear that the `index.d.ts` file is
coupled in any way to `index.js` in tests.  If I hadn't looked at other
PRs I wouldn't even have thought to update it along with new vendor
entries.

Looking forward to any feedback you have on this PR.  We are pretty
excited about the idea of having one less module to maintain so we can
focus on package management and not ci detection.
