### PR TITLE
chore: create typings at pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+node create-typings.js
+
+git add index.d.ts

--- a/create-typings.js
+++ b/create-typings.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const fs = require('fs')
+const vendors = require('./vendors.json')
+
+function createTypings () {
+  let typings = `// This file is generated at pre-commit by running \`node create-typings.js\`.
+
+/**
+ * Returns a boolean. Will be \`true\` if the code is running on a CI server,
+ * otherwise \`false\`.
+ *
+ * Some CI servers not listed here might still trigger the \`ci.isCI\`
+ * boolean to be set to \`true\` if they use certain vendor neutral environment
+ * variables. In those cases \`ci.name\` will be \`null\` and no vendor specific
+ * boolean will be set to \`true\`.
+ */
+export const isCI: boolean;
+/**
+ * Returns a boolean if PR detection is supported for the current CI server.
+ * Will be \`true\` if a PR is being tested, otherwise \`false\`. If PR detection is
+ * not supported for the current CI server, the value will be \`null\`.
+ */
+export const isPR: boolean | null;
+/**
+ * Returns a string containing name of the CI server the code is running on. If
+ * CI server is not detected, it returns \`null\`.
+ *
+ * Don't depend on the value of this string not to change for a specific vendor.
+ * If you find your self writing \`ci.name === 'Travis CI'\`, you most likely want
+ * to use \`ci.TRAVIS\` instead.
+ */
+export const name: string | null;
+
+`
+
+  for (const { constant } of vendors) {
+    typings += `export const ${constant}: boolean;`
+    typings += '\n'
+  }
+
+  return typings
+}
+
+fs.writeFileSync('./index.d.ts', createTypings())

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+// This file is generated at pre-commit by running `node create-typings.js`.
+
 /**
  * Returns a boolean. Will be `true` if the code is running on a CI server,
  * otherwise `false`.
@@ -24,9 +26,10 @@ export const isPR: boolean | null;
  */
 export const name: string | null;
 
-export const APPVEYOR: boolean;
-export const AZURE_PIPELINES: boolean;
 export const APPCIRCLE: boolean;
+export const APPVEYOR: boolean;
+export const CODEBUILD: boolean;
+export const AZURE_PIPELINES: boolean;
 export const BAMBOO: boolean;
 export const BITBUCKET: boolean;
 export const BITRISE: boolean;
@@ -34,29 +37,28 @@ export const BUDDY: boolean;
 export const BUILDKITE: boolean;
 export const CIRCLE: boolean;
 export const CIRRUS: boolean;
-export const CODEBUILD: boolean;
-export const CODEMAGIC: boolean;
 export const CODEFRESH: boolean;
+export const CODEMAGIC: boolean;
 export const CODESHIP: boolean;
 export const DRONE: boolean;
 export const DSARI: boolean;
 export const EAS: boolean;
-export const GERRIT: boolean;
 export const GITHUB_ACTIONS: boolean;
 export const GITLAB: boolean;
 export const GOCD: boolean;
 export const GOOGLE_CLOUD_BUILD: boolean;
+export const LAYERCI: boolean;
+export const GERRIT: boolean;
 export const HEROKU: boolean;
 export const HUDSON: boolean;
 export const JENKINS: boolean;
-export const LAYERCI: boolean;
 export const MAGNUM: boolean;
 export const NETLIFY: boolean;
 export const NEVERCODE: boolean;
 export const RENDER: boolean;
 export const SAIL: boolean;
-export const SEMAPHORE: boolean;
 export const SCREWDRIVER: boolean;
+export const SEMAPHORE: boolean;
 export const SHIPPABLE: boolean;
 export const SOLANO: boolean;
 export const STRIDER: boolean;
@@ -65,6 +67,6 @@ export const TEAMCITY: boolean;
 export const TRAVIS: boolean;
 export const VERCEL: boolean;
 export const APPCENTER: boolean;
+export const WOODPECKER: boolean;
 export const XCODE_CLOUD: boolean;
 export const XCODE_SERVER: boolean;
-export const WOODPECKER: boolean;

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
   ],
   "scripts": {
     "lint:fix": "standard --fix",
-    "test": "standard && node test.js"
+    "test": "standard && node test.js",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "clear-module": "^4.1.2",
+    "husky": "^8.0.2",
     "standard": "^17.0.0",
     "tape": "^5.6.1"
   },


### PR DESCRIPTION
Hey :wave:  thanks a lot for the work here :clap: . I have noticed from time to time issues with keeping typings up to date and I have seen the desire of automating them. This is not automation exactly but what it does runs a check on CI to create the typings. If there is git diff it means they are not up to date and it fails. 

_of course it will also fail if you probably do it by hand. I can add a "this is generated file" header_. Tell me if this would help i can adjust it better. 