### PR TITLE
fix: use VERCEL env var

### DIFF
--- a/test.js
+++ b/test.js
@@ -623,8 +623,8 @@ test('Vercel - NOW_BUILDER', function (t) {
   t.end()
 })
 
-test('Vercel - VERCEL_URL', function (t) {
-  process.env.VERCEL_URL = '1'
+test('Vercel - VERCEL', function (t) {
+  process.env.VERCEL = '1'
 
   clearModule('./')
   const ci = require('./')
@@ -635,7 +635,7 @@ test('Vercel - VERCEL_URL', function (t) {
   t.equal(ci.VERCEL, true)
   assertVendorConstants('VERCEL', ci, t)
 
-  delete process.env.VERCEL_URL
+  delete process.env.VERCEL
 
   t.end()
 })

--- a/vendors.json
+++ b/vendors.json
@@ -221,7 +221,7 @@
   {
     "name": "Vercel",
     "constant": "VERCEL",
-    "env": { "any": ["NOW_BUILDER", "VERCEL_URL"] }
+    "env": { "any": ["NOW_BUILDER", "VERCEL"] }
   },
   {
     "name": "Visual Studio App Center",


### PR DESCRIPTION
The `VERCEL` env var is a little more canonical for checking existence, rather than `VERCEL_URL` which checks the deployment's unique url.

https://vercel.com/docs/concepts/projects/environment-variables#system-environment-variables