### PR TITLE
chore: ignore common lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,8 @@ jspm_packages/
 
 # Lock files
 package-lock.json
+pnpm-lock.yaml
+yarn.lock
 
 # Snowpack dependency directory (https://snowpack.dev/)
 web_modules/


### PR DESCRIPTION
This will ignore lock files generated from `npm install`, `pnpm install`, and `yarn install`