### PR TITLE
Adds Azure Pipelines & Team Foundation Server

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ exports.isCI = !!(
   env.CI_NAME || // Codeship and others
   env.CONTINUOUS_INTEGRATION || // Travis CI, Cirrus CI
   env.RUN_ID || // TaskCluster, dsari
+  env.TF_BUILD || // Azure Pipelines, Team Foundation Server
   exports.name ||
   false)
 )


### PR DESCRIPTION
See: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

> `TF_BUILD`	Set to `True` if the script is being run by a build task.
>
> This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.