### PR TITLE
Uses `TF_BUILD` in vendors.json

### DIFF
--- a/test.js
+++ b/test.js
@@ -124,8 +124,8 @@ test('AppVeyor - Not PR', function (t) {
 })
 
 test('Azure Pipelines - PR', function (t) {
-  process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = 'https://dev.azure.com/Contoso'
-  process.env.SYSTEM_PULLREQUEST_PULLREQUESTID = '42'
+  process.env.TF_BUILD = 'true'
+  process.env.BUILD_REASON = 'PullRequest'
 
   clearModule('./')
   const ci = require('./')
@@ -136,14 +136,14 @@ test('Azure Pipelines - PR', function (t) {
   t.equal(ci.AZURE_PIPELINES, true)
   assertVendorConstants('AZURE_PIPELINES', ci, t)
 
-  delete process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI
-  delete process.env.SYSTEM_PULLREQUEST_PULLREQUESTID
+  delete process.env.TF_BUILD
+  delete process.env.BUILD_REASON
 
   t.end()
 })
 
 test('Azure Pipelines - Not PR', function (t) {
-  process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI = 'https://dev.azure.com/Contoso'
+  process.env.TF_BUILD = 'true'
 
   clearModule('./')
   const ci = require('./')
@@ -154,7 +154,7 @@ test('Azure Pipelines - Not PR', function (t) {
   t.equal(ci.AZURE_PIPELINES, true)
   assertVendorConstants('AZURE_PIPELINES', ci, t)
 
-  delete process.env.SYSTEM_TEAMFOUNDATIONCOLLECTIONURI
+  delete process.env.TF_BUILD
 
   t.end()
 })

--- a/vendors.json
+++ b/vendors.json
@@ -19,7 +19,9 @@
     "name": "Azure Pipelines",
     "constant": "AZURE_PIPELINES",
     "env": "TF_BUILD",
-    "pr": "SYSTEM_PULLREQUEST_PULLREQUESTID"
+    "pr": {
+      "BUILD_REASON": "PullRequest"
+    }
   },
   {
     "name": "Bamboo",

--- a/vendors.json
+++ b/vendors.json
@@ -18,7 +18,7 @@
   {
     "name": "Azure Pipelines",
     "constant": "AZURE_PIPELINES",
-    "env": "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
+    "env": "TF_BUILD",
     "pr": "SYSTEM_PULLREQUEST_PULLREQUESTID"
   },
   {


### PR DESCRIPTION
See: https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml

> `TF_BUILD` -  Set to True if the script is being run by a build task.
> 
> This variable is agent-scoped, and can be used as an environment variable in a script and as a parameter in a build task, but not as part of the build number or as a version control tag.

> `BUILD_REASON` - The event that caused the build to run. 
> - `PullRequest`: The build was triggered by a Git branch policy that requires a build.
