### PR TITLE
feat: add support for Cloudflare Pages CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Officially supported CI servers:
 | [Buildkite](https://buildkite.com)                                              | `ci.BUILDKITE`          | ✅   |
 | [CircleCI](http://circleci.com)                                                 | `ci.CIRCLE`             | ✅   |
 | [Cirrus CI](https://cirrus-ci.org)                                              | `ci.CIRRUS`             | ✅   |
+| [Cloudflare Pages](https://pages.cloudflare.com/)                               | `ci.CLOUDFLARE_PAGES`   | 🚫   |
 | [Codefresh](https://codefresh.io/)                                              | `ci.CODEFRESH`          | ✅   |
 | [Codeship](https://codeship.com)                                                | `ci.CODESHIP`           | 🚫   |
 | [Drone](https://drone.io)                                                       | `ci.DRONE`              | ✅   |

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,7 @@ export const BUDDY: boolean;
 export const BUILDKITE: boolean;
 export const CIRCLE: boolean;
 export const CIRRUS: boolean;
+export const CLOUDFLARE_PAGES: boolean;
 export const CODEFRESH: boolean;
 export const CODEMAGIC: boolean;
 export const CODESHIP: boolean;

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ exports.isCI = !!(
   env.CI !== 'false' && // Bypass all checks if CI env is explicitly set to 'false'
   (env.BUILD_ID || // Jenkins, Cloudbees
     env.BUILD_NUMBER || // Jenkins, TeamCity
-    env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+    env.CI || // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari, Cloudflare Pages
     env.CI_APP_ID || // Appflow
     env.CI_BUILD_ID || // Appflow
     env.CI_BUILD_NUMBER || // Appflow

--- a/test.js
+++ b/test.js
@@ -329,6 +329,25 @@ test('Cirrus CI - Not PR', function (t) {
   t.end()
 })
 
+test('Cloudflare Pages - Not PR', function (t) {
+  // https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables
+  process.env.CF_PAGES = '1'
+
+  clearModule('./')
+  const ci = require('./')
+
+  t.equal(ci.isCI, true)
+  t.equal(ci.isPR, null)
+  t.equal(ci.name, 'Cloudflare Pages')
+  t.equal(ci.CLOUDFLARE_PAGES, true)
+  t.equal(ci.id, 'CLOUDFLARE_PAGES')
+  assertVendorConstants('CLOUDFLARE_PAGES', ci, t)
+
+  delete process.env.CF_PAGES
+
+  t.end()
+})
+
 test('Codefresh - PR', function (t) {
   process.env.CF_BUILD_ID = 'true'
   process.env.CF_PULL_REQUEST_ID = '42'

--- a/vendors.json
+++ b/vendors.json
@@ -86,6 +86,11 @@
     "pr": "CIRRUS_PR"
   },
   {
+    "name": "Cloudflare Pages",
+    "constant": "CLOUDFLARE_PAGES",
+    "env": "CF_PAGES"
+  },
+  {
     "name": "Codefresh",
     "constant": "CODEFRESH",
     "env": "CF_BUILD_ID",


### PR DESCRIPTION
Note: Cloudflare Pages technically already injects `process.env.CI = 'true'`. However, this PR allows tools to specifically detect if the CI environment is on Cloudflare Pages by checking for the presence of the `CF_PAGES` environment variable. [Per Cloudflare's documentation](https://developers.cloudflare.com/pages/configuration/build-configuration/#environment-variables), that variable is injected by default.